### PR TITLE
Unify version and ref parameters

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -53,16 +53,13 @@
   "customManagers": [
     {
       "customType": "regex",
-      "fileMatch": [
-        "^\\.github/workflows/ci\\.yaml$"
-      ],
+      "fileMatch": ["^.*\\.ya?ml$"],
       "matchStrings": [
-        "(^|\\s)WINDSOR_VERSION:\\s*(?<currentValue>v[\\d\\.]+)"
+        "(?<currentValue>v\\d+\\.\\d+\\.\\d+(-[a-zA-Z0-9]+)?)\\s*#\\s*renovate:\\s*datasource=(?<datasource>[^\\s]+)\\s*depName=(?<depName>[^\\s]+)"
       ],
-      "depNameTemplate": "WINDSOR_VERSION",
-      "datasourceTemplate": "github-tags",
-      "packageNameTemplate": "windsorcli/cli",
-      "versioningTemplate": "semver"
+      "versioningTemplate": "semver",
+      "datasourceTemplate": "{{datasource}}",
+      "packageNameTemplate": "{{depName}}"
     }
   ],
   "labels": [

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,7 @@ on:
   push:
 
 env:
-  WINDSOR_VERSION: v0.5.6
+  WINDSOR_VERSION: v0.5.6  # renovate: datasource=github-releases depName=windsorcli/cli
   WINDSOR_CONTEXT: test
 
 jobs:
@@ -24,22 +24,12 @@ jobs:
           terraform_version: 1.11.4
           terraform_wrapper: false
 
-      - name: Verify Terraform Installation
-        shell: pwsh
-        if: matrix.os == 'windows-latest'
-        run: terraform version
-
-      - name: Verify Terraform Installation
-        shell: bash
-        if: matrix.os != 'windows-latest'
-        run: terraform version
-
       - name: Install Windsor CLI
         uses: ./
         with:
           verbose: true
           workdir: test
-          version: ${{ env.WINDSOR_VERSION }}
+          ref: ${{ env.WINDSOR_VERSION }}
           context: ${{ env.WINDSOR_CONTEXT }}
 
       - name: Verify Windsor Context
@@ -94,7 +84,7 @@ jobs:
         with:
           verbose: true
           workdir: test/terraform/sample
-          version: ${{ env.WINDSOR_VERSION }}
+          ref: ${{ env.WINDSOR_VERSION }}
           context: ${{ env.WINDSOR_CONTEXT }}
 
       - name: Assert TF_ environment variables are injected

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,8 @@ env:
   WINDSOR_CONTEXT: test
 
 jobs:
-  windsorcli:
+  test:
+    if: github.event_name != 'schedule' || github.ref == 'refs/heads/main'
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 6 * * *'  # Run at 2AM ET / 6AM UTC
 
 env:
   WINDSOR_CONTEXT: test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,6 +2,8 @@ name: CI
 
 on:
   push:
+  schedule:
+    - cron: '0 0 * * *'
 
 env:
   WINDSOR_CONTEXT: test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,6 @@ on:
   push:
 
 env:
-  WINDSOR_VERSION: v0.5.6  # renovate: datasource=github-releases depName=windsorcli/cli
   WINDSOR_CONTEXT: test
 
 jobs:
@@ -12,11 +11,19 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
+        ref: 
+          - v0.5.6 # renovate: datasource=github-releases depName=windsorcli/cli
+          - main
     runs-on: ${{ matrix.os }}
   
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Setup Go
+        uses: actions/setup-go@bb65d8857b81c74a671e81f935d3362a5d718e2f # v4.2.1
+        with:
+          go-version: 1.24.2
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
@@ -29,7 +36,7 @@ jobs:
         with:
           verbose: true
           workdir: test
-          ref: ${{ env.WINDSOR_VERSION }}
+          ref: ${{ matrix.ref }}
           context: ${{ env.WINDSOR_CONTEXT }}
 
       - name: Verify Windsor Context
@@ -84,7 +91,7 @@ jobs:
         with:
           verbose: true
           workdir: test/terraform/sample
-          ref: ${{ env.WINDSOR_VERSION }}
+          ref: ${{ matrix.ref }}
           context: ${{ env.WINDSOR_CONTEXT }}
 
       - name: Assert TF_ environment variables are injected

--- a/action.yaml
+++ b/action.yaml
@@ -3,14 +3,9 @@ name: 'Windsor CLI Action'
 description: 'Installs and configures the Windsor CLI for use in GitHub Actions'
 
 inputs:
-  version:
-    description: 'The version of Windsor CLI to install'
-    required: false
-    default: v0.5.6
   ref:
-    description: 'Git reference to build Windsor CLI from source'
-    required: false
-    default: ""
+    description: 'Git reference to build Windsor CLI from source or version tag to download'
+    required: true
   context:
     description: 'The context to use for Windsor CLI commands'
     required: false
@@ -81,14 +76,12 @@ runs:
           const installFolder = path.resolve(process.env.GITHUB_WORKSPACE, 'bin');
           const windsorExecutable = isWindows ? 'windsor.exe' : 'windsor';
           const githubWorkspace = process.env.GITHUB_WORKSPACE;
-          let version = cleanInput('${{ inputs.version }}');
           const ref = cleanInput('${{ inputs.ref }}');
           const input_context = cleanInput('${{ inputs.context }}');
           let rawWorkdir = cleanInput('${{ inputs.workdir }}');
           
           if (verbose) {
             console.log('Installation parameters:');
-            console.log('- Version:', version);
             console.log('- Ref:', ref);
             console.log('- Context:', input_context);
             console.log('- Workdir:', rawWorkdir);
@@ -166,56 +159,57 @@ runs:
             const arch = process.arch === 'arm64' ? 'arm64' : 'amd64';
             const osType = isWindows ? 'windows' : process.platform === 'darwin' ? 'darwin' : 'linux';
 
-            if (ref) {
-              if (verbose) console.log(`Installing Windsor CLI from ref: ${ref}`);
-              execCommand(`git clone https://github.com/windsorcli/cli.git ${githubWorkspace}/cli`);
-              execCommand(`cd ${githubWorkspace}/cli && git pull && git checkout ${ref}`);
-              execCommand(`cd ${githubWorkspace}/cli/cmd/windsor && go build -o ${path.join(installFolder, windsorExecutable)}`);
-              version = 'vdev';
-            } else {
-              const numericVersion = version.replace(/^v/, '');
+            // Check if ref is a version tag (including any semver prerelease)
+            const isVersionTag = /^v\d+\.\d+\.\d+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$/.test(ref);
+            
+            if (isVersionTag) {
+              if (verbose) console.log(`Attempting to download Windsor CLI version: ${ref}`);
+              const numericVersion = ref.replace(/^v/, '');
               const localFileName = `windsor_${numericVersion}_${osType}_${arch}.tar.gz`;
-              const downloadUrl = `https://github.com/windsorcli/cli/releases/download/${version}/${localFileName}`;
-
-              if (verbose) console.log('Downloading Windsor CLI:', downloadUrl);
-
-              const curlCommand = `curl -L -o ${localFileName} ${downloadUrl}`;
-              const mkdirCommand = isWindows ? `if not exist "${installFolder}" mkdir "${installFolder}"` : `mkdir -p "${installFolder}"`;
-              const extractCommand = isWindows 
-                ? `powershell -Command "tar -xzf ${localFileName} -C ${installFolder}"`
-                : `tar -xzf ${localFileName} -C "${installFolder}"`;
-              const chmodCommand = isWindows 
-                ? `icacls "${path.join(installFolder, windsorExecutable)}" /grant Everyone:F`
-                : `chmod +x "${path.join(installFolder, windsorExecutable)}"`;
-              const rmCommand = isWindows ? `del ${localFileName}` : `rm -rf ${localFileName}`;
+              const downloadUrl = `https://github.com/windsorcli/cli/releases/download/${ref}/${localFileName}`;
 
               try {
+                if (verbose) console.log('Downloading Windsor CLI:', downloadUrl);
+                const curlCommand = `curl -L -o ${localFileName} ${downloadUrl}`;
+                const mkdirCommand = isWindows ? `if not exist "${installFolder}" mkdir "${installFolder}"` : `mkdir -p "${installFolder}"`;
+                const extractCommand = isWindows 
+                  ? `powershell -Command "tar -xzf ${localFileName} -C ${installFolder}"`
+                  : `tar -xzf ${localFileName} -C "${installFolder}"`;
+                const chmodCommand = isWindows 
+                  ? `icacls "${path.join(installFolder, windsorExecutable)}" /grant Everyone:F`
+                  : `chmod +x "${path.join(installFolder, windsorExecutable)}"`;
+                const rmCommand = isWindows ? `del ${localFileName}` : `rm -rf ${localFileName}`;
+
                 execCommand(curlCommand);
                 execCommand(mkdirCommand);
                 execCommand(extractCommand);
                 execCommand(chmodCommand);
                 execCommand(rmCommand);
+
+                let installedVersionOutput = execSync(`${path.join(installFolder, windsorExecutable)} version`).toString().trim();
+                let installedVersionMatch = installedVersionOutput.match(/^Version:\s*(\S+)/);
+                let installedVersion = installedVersionMatch ? `v${installedVersionMatch[1]}` : '';
+
+                if (verbose) {
+                  console.log('Version check:');
+                  console.log('- Expected:', ref);
+                  console.log('- Installed:', installedVersion);
+                }
+
+                if (installedVersion !== ref) {
+                  throw new Error(`Version mismatch: expected ${ref}, got ${installedVersion}`);
+                }
               } catch (error) {
-                console.error('Error executing commands');
-                if (verbose) console.error('Error details:', error.message);
-                process.exit(1);
-              }
-
-              let installedVersionOutput = execSync(`${path.join(installFolder, windsorExecutable)} version`).toString().trim();
-              let installedVersionMatch = installedVersionOutput.match(/^Version:\s*(\S+)/);
-              let installedVersion = installedVersionMatch ? `v${installedVersionMatch[1]}` : '';
-
-              if (verbose) {
-                console.log('Version check:');
-                console.log('- Expected:', version);
-                console.log('- Installed:', installedVersion);
-              }
-
-              if (installedVersion !== version) {
-                console.error(`Version mismatch: expected ${version}, got ${installedVersion}`);
-                process.exit(1);
+                if (verbose) console.log('Failed to download version, falling back to building from source:', error.message);
+                // Fall through to build from source
               }
             }
+
+            // If not a version tag or download failed, build from source
+            if (verbose) console.log(`Building Windsor CLI from ref: ${ref}`);
+            execCommand(`git clone https://github.com/windsorcli/cli.git ${githubWorkspace}/cli`);
+            execCommand(`cd ${githubWorkspace}/cli && git pull && git checkout ${ref}`);
+            execCommand(`cd ${githubWorkspace}/cli/cmd/windsor && go build -o ${path.join(installFolder, windsorExecutable)}`);
           }
 
           fs.appendFileSync(process.env.GITHUB_PATH, `${installFolder}\n`);

--- a/action.yaml
+++ b/action.yaml
@@ -39,28 +39,6 @@ runs:
             process.exit(1);
           }
 
-    - name: Check Go Installation
-      if: ${{ inputs.ref != '' }}
-      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
-      with:
-        script: |
-          const { execSync } = require('child_process');
-          const os = require('os');
-          const verbose = '${{ inputs.verbose }}' === 'true';
-
-          try {
-            const platform = os.platform();
-            let goPathCommand = platform === 'win32' ? 'where go' : 'which go';
-            const goPath = execSync(goPathCommand, { encoding: 'utf-8' }).trim();
-            if (verbose) console.log('Go binary path:', goPath);
-            
-            const goVersion = execSync('go version', { encoding: 'utf-8' }).trim();
-            if (verbose) console.log('Go version:', goVersion);
-          } catch (error) {
-            console.error('Go is not installed or not found in PATH');
-            process.exit(1);
-          }
-
     - name: Install Windsor CLI
       uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
       with:
@@ -160,7 +138,7 @@ runs:
             const arch = process.arch === 'arm64' ? 'arm64' : 'amd64';
             const osType = isWindows ? 'windows' : process.platform === 'darwin' ? 'darwin' : 'linux';
 
-            // Check if ref is a version tag (including any semver prerelease)
+            // Check if ref is a version tag
             const isVersionTag = /^v\d+\.\d+\.\d+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$/.test(ref);
             
             if (isVersionTag) {
@@ -206,11 +184,26 @@ runs:
               }
             }
 
-            // If not a version tag or download failed, build from source
-            if (verbose) console.log(`Building Windsor CLI from ref: ${ref}`);
-            execCommand(`git clone https://github.com/windsorcli/cli.git ${githubWorkspace}/cli`);
-            execCommand(`cd ${githubWorkspace}/cli && git pull && git checkout ${ref}`);
-            execCommand(`cd ${githubWorkspace}/cli/cmd/windsor && go build -o ${path.join(installFolder, windsorExecutable)}`);
+            // If not a version tag or download failed, check for Go and build from source
+            if (!isVersionTag || !fs.existsSync(path.join(installFolder, windsorExecutable))) {
+              try {
+                const platform = os.platform();
+                let goPathCommand = platform === 'win32' ? 'where go' : 'which go';
+                const goPath = execSync(goPathCommand, { encoding: 'utf-8' }).trim();
+                if (verbose) console.log('Go binary path:', goPath);
+                
+                const goVersion = execSync('go version', { encoding: 'utf-8' }).trim();
+                if (verbose) console.log('Go version:', goVersion);
+
+                if (verbose) console.log(`Building Windsor CLI from ref: ${ref}`);
+                execCommand(`git clone https://github.com/windsorcli/cli.git ${githubWorkspace}/cli`);
+                execCommand(`cd ${githubWorkspace}/cli && git pull && git checkout ${ref}`);
+                execCommand(`cd ${githubWorkspace}/cli/cmd/windsor && go build -o ${path.join(installFolder, windsorExecutable)}`);
+              } catch (error) {
+                console.error('Go is not installed or not found in PATH');
+                process.exit(1);
+              }
+            }
           }
 
           fs.appendFileSync(process.env.GITHUB_PATH, `${installFolder}\n`);

--- a/action.yaml
+++ b/action.yaml
@@ -5,7 +5,8 @@ description: 'Installs and configures the Windsor CLI for use in GitHub Actions'
 inputs:
   ref:
     description: 'Git reference to build Windsor CLI from source or version tag to download'
-    required: true
+    required: false
+    default: v0.5.6  # renovate: datasource=github-releases depName=windsorcli/cli
   context:
     description: 'The context to use for Windsor CLI commands'
     required: false


### PR DESCRIPTION
We now only use a `ref` rather than a `version`. This allows for a consistent input that involves any git reference, and it will only download binaries when matching valid semantic versioned tags.