### PR TITLE
feat: add optional vm-driver parameter to windsor init

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,6 +17,13 @@ jobs:
         ref: 
           - v0.5.7 # renovate: datasource=github-releases depName=windsorcli/cli
           - main
+        include:
+          - os: ubuntu-latest
+            vm-driver: docker
+          - os: windows-latest
+            vm-driver: docker-desktop
+          - os: macos-latest
+            vm-driver: docker-desktop
     runs-on: ${{ matrix.os }}
   
     steps:
@@ -41,6 +48,7 @@ jobs:
           workdir: test
           ref: ${{ matrix.ref }}
           context: ${{ env.WINDSOR_CONTEXT }}
+          vm-driver: ${{ matrix.vm-driver }}
 
       - name: Verify Windsor Context
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
@@ -75,6 +83,7 @@ jobs:
               'OMNICONFIG',
               'TALOSCONFIG',
               'WINDSOR_CONTEXT',
+              'WINDSOR_CONTEXT_ID',
               'WINDSOR_PROJECT_ROOT'
             ];
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -83,7 +83,6 @@ jobs:
               'OMNICONFIG',
               'TALOSCONFIG',
               'WINDSOR_CONTEXT',
-              'WINDSOR_CONTEXT_ID',
               'WINDSOR_PROJECT_ROOT'
             ];
 

--- a/action.yaml
+++ b/action.yaml
@@ -19,6 +19,10 @@ inputs:
     description: 'Enable verbose logging'
     required: false
     default: "false"
+  vm-driver:
+    description: 'VM driver to use for Windsor CLI init command'
+    required: false
+    default: ""
 
 runs:
   using: 'composite'
@@ -231,6 +235,7 @@ runs:
           const input_context = '${{ inputs.context }}';
           const workdir = '${{ inputs.workdir }}';
           const verbose = '${{ inputs.verbose }}' === 'true';
+          const vmDriver = '${{ inputs.vm-driver }}';
 
           console.log('Environment setup:');
           console.log('- Install folder:', installFolder);
@@ -245,7 +250,7 @@ runs:
 
           if (input_context) {
             try {
-              const command = `${windsorExecutable} init ${input_context}${verbose ? ' --verbose' : ''}`;
+              const command = `${windsorExecutable} init ${input_context}${vmDriver ? ` --vm-driver ${vmDriver}` : ''}${verbose ? ' --verbose' : ''}`;
               if (verbose) {
                 console.log('Environment setup:');
                 console.log('- Current directory:', process.cwd());


### PR DESCRIPTION
- Add vm-driver input parameter to action.yaml

- Pass --vm-driver flag to windsor init when parameter is provided

- Update CI matrix to test vm-driver with appropriate values per OS

  - docker for ubuntu-latest

  - docker-desktop for windows-latest and macos-latest