### PR TITLE
feat: Install only

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -192,13 +192,7 @@ jobs:
 
   test-install-only:
     if: github.event_name != 'schedule' || github.ref == 'refs/heads/main'
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-        ref: 
-          - v0.5.7 # renovate: datasource=github-releases depName=windsorcli/cli
-          - main
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
   
     steps:
       - name: Checkout code
@@ -213,7 +207,7 @@ jobs:
         uses: ./
         with:
           verbose: true
-          ref: ${{ matrix.ref }}
+          ref: main
           install-only: true
 
       - name: Verify CLI is installed but not initialized

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,12 +5,11 @@ on:
   schedule:
     - cron: '0 6 * * *'  # Run at 2AM ET / 6AM UTC
 
-env:
-  WINDSOR_CONTEXT: test
-
 jobs:
   test:
     if: github.event_name != 'schedule' || github.ref == 'refs/heads/main'
+    env:
+      WINDSOR_CONTEXT: test
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
@@ -188,5 +187,73 @@ jobs:
               console.error('Error running Terraform:', error.message);
               if (error.stdout) console.error('stdout:', error.stdout);
               if (error.stderr) console.error('stderr:', error.stderr);
+              process.exit(1);
+            }
+
+  test-install-only:
+    if: github.event_name != 'schedule' || github.ref == 'refs/heads/main'
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        ref: 
+          - v0.5.7 # renovate: datasource=github-releases depName=windsorcli/cli
+          - main
+    runs-on: ${{ matrix.os }}
+  
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Setup Go
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        with:
+          go-version: 1.24.2
+
+      - name: Install Windsor CLI (install-only)
+        uses: ./
+        with:
+          verbose: true
+          ref: ${{ matrix.ref }}
+          install-only: true
+
+      - name: Verify CLI is installed but not initialized
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const { execSync } = require('child_process');
+            const fs = require('fs');
+            const path = require('path');
+
+            try {
+              // Verify CLI is installed and executable
+              const versionOutput = execSync('windsor version', { stdio: 'pipe' }).toString().trim();
+              console.log('Windsor CLI version:', versionOutput);
+
+              // Verify environment variables are not set
+              const requiredEnvVars = [
+                'KUBECONFIG',
+                'KUBE_CONFIG_PATH',
+                'OMNICONFIG',
+                'TALOSCONFIG',
+                'WINDSOR_CONTEXT',
+                'WINDSOR_PROJECT_ROOT'
+              ];
+
+              const setVars = requiredEnvVars.filter(varName => process.env[varName]);
+              if (setVars.length > 0) {
+                console.error('Error: Environment variables should not be set in install-only mode:', setVars);
+                process.exit(1);
+              }
+
+              // Verify windsor.yaml was not created
+              if (fs.existsSync('windsor.yaml')) {
+                console.error('Error: windsor.yaml was created in install-only mode');
+                process.exit(1);
+              }
+
+              console.log('✓ No environment variables are set as expected');
+              console.log('✓ windsor.yaml was not created as expected');
+            } catch (error) {
+              console.error('Error:', error.message);
               process.exit(1);
             }

--- a/README.md
+++ b/README.md
@@ -7,8 +7,7 @@ This GitHub Action installs and configures the Windsor CLI for use in GitHub Act
 ### `version`
 - **Description**: The version of Windsor CLI to install
 - **Required**: No
-- **Default**: `v0.5.2`
-- **Example**: `v0.5.6`
+- **Default**: `v0.5.7`
 
 ### `ref`
 - **Description**: Git reference to build Windsor CLI from source instead of downloading a release. Requires Go to be installed.
@@ -32,7 +31,11 @@ This GitHub Action installs and configures the Windsor CLI for use in GitHub Act
 - **Description**: Enable verbose logging for debugging purposes
 - **Required**: No
 - **Default**: `"false"`
-- **Example**: `"true"`
+
+### `install-only`
+- **Description**: Only install the CLI without initializing context or injecting environment variables
+- **Required**: No
+- **Default**: `"false"`
 
 ## Usage
 
@@ -41,7 +44,7 @@ steps:
   - name: Install Windsor CLI
     uses: windsorcli/action@v1
     with:
-      version: v0.5.6
+      version: v0.5.7
       context: local
       workdir: .windsor/.tf_modules/cluster/talos
 ```
@@ -90,7 +93,7 @@ jobs:
       - name: Install Windsor CLI
         uses: ./
         with:
-          version: v0.5.6
+          version: v0.5.7
           context: local
           workdir: terraform/cluster/eks
           # verbose: true  # Only enable for debugging

--- a/action.yaml
+++ b/action.yaml
@@ -19,6 +19,10 @@ inputs:
     description: 'Enable verbose logging'
     required: false
     default: "false"
+  install-only:
+    description: 'Only install the CLI without initializing context or injecting environment variables'
+    required: false
+    default: "false"
 
 runs:
   using: 'composite'
@@ -217,6 +221,7 @@ runs:
 
     - name: Set Windsor CLI environment variables
       uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+      if: ${{ inputs.install-only != 'true' }}
       with:
         script: |
           const { execSync } = require('child_process');


### PR DESCRIPTION
Adds the ability to set `install-only: true` which will install the windsor CLI without initializing and injecting environment variables.