### PR TITLE
Install to runner tool cache

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -198,7 +198,10 @@ runs:
                 fs.mkdirSync(tmpDir, { recursive: true });
                 execCommand(`git clone https://github.com/windsorcli/cli.git ${tmpDir}`);
                 execCommand(`cd ${tmpDir} && git pull && git checkout ${ref}`);
-                execCommand(`cd ${tmpDir} && go mod init github.com/windsorcli/cli && go mod tidy`);
+                if (!fs.existsSync(path.join(tmpDir, 'go.mod'))) {
+                  execCommand(`cd ${tmpDir} && go mod init github.com/windsorcli/cli`);
+                }
+                execCommand(`cd ${tmpDir} && go mod tidy`);
                 execCommand(`cd ${tmpDir}/cmd/windsor && go build -o ${path.join(installFolder, windsorExecutable)}`);
                 fs.rmSync(tmpDir, { recursive: true, force: true });
               } catch (error) {

--- a/action.yaml
+++ b/action.yaml
@@ -198,6 +198,7 @@ runs:
                 fs.mkdirSync(tmpDir, { recursive: true });
                 execCommand(`git clone https://github.com/windsorcli/cli.git ${tmpDir}`);
                 execCommand(`cd ${tmpDir} && git pull && git checkout ${ref}`);
+                execCommand(`cd ${tmpDir} && go mod init github.com/windsorcli/cli && go mod tidy`);
                 execCommand(`cd ${tmpDir}/cmd/windsor && go build -o ${path.join(installFolder, windsorExecutable)}`);
                 fs.rmSync(tmpDir, { recursive: true, force: true });
               } catch (error) {

--- a/action.yaml
+++ b/action.yaml
@@ -151,13 +151,13 @@ runs:
               try {
                 if (verbose) console.log('Downloading Windsor CLI:', downloadUrl);
                 const curlCommand = `curl -L -o ${localFileName} ${downloadUrl}`;
-                const mkdirCommand = isWindows ? `if not exist "${installFolder}" mkdir "${installFolder}"` : `sudo mkdir -p "${installFolder}"`;
+                const mkdirCommand = isWindows ? `if not exist "${installFolder}" mkdir "${installFolder}"` : `mkdir -p "${installFolder}"`;
                 const extractCommand = isWindows 
                   ? `powershell -Command "Expand-Archive -Path ${localFileName} -DestinationPath ${installFolder} -Force"`
                   : `tar -xzf ${localFileName} -C "${installFolder}"`;
                 const chmodCommand = isWindows 
                   ? `icacls "${path.join(installFolder, windsorExecutable)}" /grant Everyone:F`
-                  : `sudo chmod +x "${path.join(installFolder, windsorExecutable)}"`;
+                  : `chmod +x "${path.join(installFolder, windsorExecutable)}"`;
                 const rmCommand = isWindows ? `del ${localFileName}` : `rm -rf ${localFileName}`;
 
                 execCommand(curlCommand);

--- a/action.yaml
+++ b/action.yaml
@@ -50,12 +50,15 @@ runs:
           
           const cleanInput = (input) => typeof input === 'string' ? input.replace(/\r?\n|\r/g, '') : input;
           const verbose = '${{ inputs.verbose }}' === 'true';
+          const ref = cleanInput('${{ inputs.ref }}');
+          const isVersionTag = /^v?\d+\.\d+\.\d+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$/i.test(ref);
 
           const isWindows = os.platform() === 'win32';
-          const installFolder = path.join(process.env.RUNNER_TOOL_CACHE, 'windsor', ref);
+          const installFolder = isVersionTag 
+            ? path.join(process.env.RUNNER_TOOL_CACHE, 'windsor', ref)
+            : path.join(process.env.GITHUB_WORKSPACE, 'bin');
           const windsorExecutable = isWindows ? 'windsor.exe' : 'windsor';
           const githubWorkspace = process.env.GITHUB_WORKSPACE;
-          const ref = cleanInput('${{ inputs.ref }}');
           const input_context = cleanInput('${{ inputs.context }}');
           let rawWorkdir = cleanInput('${{ inputs.workdir }}');
           
@@ -137,7 +140,7 @@ runs:
             const osType = isWindows ? 'windows' : process.platform === 'darwin' ? 'darwin' : 'linux';
 
             // Check if ref is a version tag
-            const isVersionTag = /^v\d+\.\d+\.\d+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$/.test(ref);
+            const isVersionTag = /^v?\d+\.\d+\.\d+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$/i.test(ref);
             
             if (isVersionTag) {
               if (verbose) console.log(`Attempting to download Windsor CLI version: ${ref}`);

--- a/action.yaml
+++ b/action.yaml
@@ -52,7 +52,7 @@ runs:
           const verbose = '${{ inputs.verbose }}' === 'true';
 
           const isWindows = os.platform() === 'win32';
-          const installFolder = path.resolve(process.env.GITHUB_WORKSPACE, 'bin');
+          const installFolder = path.join(process.env.RUNNER_TOOL_CACHE, 'windsor', ref);
           const windsorExecutable = isWindows ? 'windsor.exe' : 'windsor';
           const githubWorkspace = process.env.GITHUB_WORKSPACE;
           const ref = cleanInput('${{ inputs.ref }}');
@@ -148,13 +148,13 @@ runs:
               try {
                 if (verbose) console.log('Downloading Windsor CLI:', downloadUrl);
                 const curlCommand = `curl -L -o ${localFileName} ${downloadUrl}`;
-                const mkdirCommand = isWindows ? `if not exist "${installFolder}" mkdir "${installFolder}"` : `mkdir -p "${installFolder}"`;
+                const mkdirCommand = isWindows ? `if not exist "${installFolder}" mkdir "${installFolder}"` : `sudo mkdir -p "${installFolder}"`;
                 const extractCommand = isWindows 
                   ? `powershell -Command "Expand-Archive -Path ${localFileName} -DestinationPath ${installFolder} -Force"`
                   : `tar -xzf ${localFileName} -C "${installFolder}"`;
                 const chmodCommand = isWindows 
                   ? `icacls "${path.join(installFolder, windsorExecutable)}" /grant Everyone:F`
-                  : `chmod +x "${path.join(installFolder, windsorExecutable)}"`;
+                  : `sudo chmod +x "${path.join(installFolder, windsorExecutable)}"`;
                 const rmCommand = isWindows ? `del ${localFileName}` : `rm -rf ${localFileName}`;
 
                 execCommand(curlCommand);
@@ -194,9 +194,13 @@ runs:
                 if (verbose) console.log('Go version:', goVersion);
 
                 if (verbose) console.log(`Building Windsor CLI from ref: ${ref}`);
-                execCommand(`git clone https://github.com/windsorcli/cli.git ${githubWorkspace}/cli`);
-                execCommand(`cd ${githubWorkspace}/cli && git pull && git checkout ${ref}`);
-                execCommand(`cd ${githubWorkspace}/cli/cmd/windsor && go build -o ${path.join(installFolder, windsorExecutable)}`);
+                const tmpDir = path.join(os.tmpdir(), `windsor-build-${Date.now()}`);
+                if (verbose) console.log('Using temporary build directory:', tmpDir);
+                fs.mkdirSync(tmpDir, { recursive: true });
+                execCommand(`git clone https://github.com/windsorcli/cli.git ${tmpDir}`);
+                execCommand(`cd ${tmpDir} && git pull && git checkout ${ref}`);
+                execCommand(`cd ${tmpDir}/cmd/windsor && go build -o ${path.join(installFolder, windsorExecutable)}`);
+                fs.rmSync(tmpDir, { recursive: true, force: true });
               } catch (error) {
                 console.error(error.message);
                 process.exit(1);
@@ -225,7 +229,7 @@ runs:
           const os = require('os');
 
           const isWindows = os.platform() === 'win32';
-          const installFolder = path.resolve(process.env.GITHUB_WORKSPACE, 'bin');
+          const installFolder = path.join(process.env.RUNNER_TOOL_CACHE, 'windsor', ref);
           const windsorExecutable = isWindows ? 'windsor.exe' : 'windsor';
           const githubEnv = process.env.GITHUB_ENV;
           const input_context = '${{ inputs.context }}';

--- a/action.yaml
+++ b/action.yaml
@@ -198,11 +198,14 @@ runs:
                 fs.mkdirSync(tmpDir, { recursive: true });
                 execCommand(`git clone https://github.com/windsorcli/cli.git ${tmpDir}`);
                 execCommand(`cd ${tmpDir} && git pull && git checkout ${ref}`);
-                if (!fs.existsSync(path.join(tmpDir, 'go.mod'))) {
-                  execCommand(`cd ${tmpDir} && go mod init github.com/windsorcli/cli`);
+                
+                // Ensure we're in the correct directory for Go commands
+                process.chdir(tmpDir);
+                if (!fs.existsSync('go.mod')) {
+                  execCommand('go mod init github.com/windsorcli/cli');
                 }
-                execCommand(`cd ${tmpDir} && go mod tidy`);
-                execCommand(`cd ${tmpDir}/cmd/windsor && go build -o ${path.join(installFolder, windsorExecutable)}`);
+                execCommand('go mod tidy');
+                execCommand(`cd cmd/windsor && go build -o ${path.join(installFolder, windsorExecutable)}`);
                 fs.rmSync(tmpDir, { recursive: true, force: true });
               } catch (error) {
                 console.error(error.message);

--- a/action.yaml
+++ b/action.yaml
@@ -54,12 +54,13 @@ runs:
           const isVersionTag = /^v?\d+\.\d+\.\d+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$/i.test(ref);
 
           const isWindows = os.platform() === 'win32';
-          const installFolder = isVersionTag 
-            ? path.join(process.env.RUNNER_TOOL_CACHE, 'windsor', ref)
-            : path.join(process.env.GITHUB_WORKSPACE, 'bin');
+          const ref = '${{ inputs.ref }}';
+          const installFolder = path.join(process.env.RUNNER_TOOL_CACHE, 'windsor', ref);
           const windsorExecutable = isWindows ? 'windsor.exe' : 'windsor';
-          const githubWorkspace = process.env.GITHUB_WORKSPACE;
-          const input_context = cleanInput('${{ inputs.context }}');
+          const githubEnv = process.env.GITHUB_ENV;
+          const input_context = '${{ inputs.context }}';
+          const workdir = '${{ inputs.workdir }}';
+          const verbose = '${{ inputs.verbose }}' === 'true';
           let rawWorkdir = cleanInput('${{ inputs.workdir }}');
           
           if (verbose) {
@@ -72,7 +73,7 @@ runs:
           
           let workdir;
           if (rawWorkdir) {
-            const workspacePath = process.env.GITHUB_WORKSPACE || githubWorkspace;
+            const workspacePath = process.env.GITHUB_WORKSPACE || process.env.GITHUB_WORKSPACE;
             // Simple path normalization - no quotes, just slashes
             const platformPath = rawWorkdir.replace(/\//g, path.sep);
             
@@ -233,13 +234,13 @@ runs:
           const os = require('os');
 
           const isWindows = os.platform() === 'win32';
+          const ref = '${{ inputs.ref }}';
           const installFolder = path.join(process.env.RUNNER_TOOL_CACHE, 'windsor', ref);
           const windsorExecutable = isWindows ? 'windsor.exe' : 'windsor';
           const githubEnv = process.env.GITHUB_ENV;
           const input_context = '${{ inputs.context }}';
           const workdir = '${{ inputs.workdir }}';
           const verbose = '${{ inputs.verbose }}' === 'true';
-          const ref = '${{ inputs.ref }}';
 
           console.log('Environment setup:');
           console.log('- Install folder:', installFolder);

--- a/action.yaml
+++ b/action.yaml
@@ -239,6 +239,7 @@ runs:
           const input_context = '${{ inputs.context }}';
           const workdir = '${{ inputs.workdir }}';
           const verbose = '${{ inputs.verbose }}' === 'true';
+          const ref = '${{ inputs.ref }}';
 
           console.log('Environment setup:');
           console.log('- Install folder:', installFolder);

--- a/action.yaml
+++ b/action.yaml
@@ -54,13 +54,10 @@ runs:
           const isVersionTag = /^v?\d+\.\d+\.\d+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$/i.test(ref);
 
           const isWindows = os.platform() === 'win32';
-          const ref = '${{ inputs.ref }}';
           const installFolder = path.join(process.env.RUNNER_TOOL_CACHE, 'windsor', ref);
           const windsorExecutable = isWindows ? 'windsor.exe' : 'windsor';
           const githubEnv = process.env.GITHUB_ENV;
           const input_context = '${{ inputs.context }}';
-          const workdir = '${{ inputs.workdir }}';
-          const verbose = '${{ inputs.verbose }}' === 'true';
           let rawWorkdir = cleanInput('${{ inputs.workdir }}');
           
           if (verbose) {
@@ -73,7 +70,7 @@ runs:
           
           let workdir;
           if (rawWorkdir) {
-            const workspacePath = process.env.GITHUB_WORKSPACE || process.env.GITHUB_WORKSPACE;
+            const workspacePath = process.env.GITHUB_WORKSPACE;
             // Simple path normalization - no quotes, just slashes
             const platformPath = rawWorkdir.replace(/\//g, path.sep);
             
@@ -140,9 +137,6 @@ runs:
             const arch = process.arch === 'arm64' ? 'arm64' : 'amd64';
             const osType = isWindows ? 'windows' : process.platform === 'darwin' ? 'darwin' : 'linux';
 
-            // Check if ref is a version tag
-            const isVersionTag = /^v?\d+\.\d+\.\d+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$/i.test(ref);
-            
             if (isVersionTag) {
               if (verbose) console.log(`Attempting to download Windsor CLI version: ${ref}`);
               const numericVersion = ref.replace(/^v/, '');
@@ -234,8 +228,7 @@ runs:
           const os = require('os');
 
           const isWindows = os.platform() === 'win32';
-          const ref = '${{ inputs.ref }}';
-          const installFolder = path.join(process.env.RUNNER_TOOL_CACHE, 'windsor', ref);
+          const installFolder = path.join(process.env.RUNNER_TOOL_CACHE, 'windsor', '${{ inputs.ref }}');
           const windsorExecutable = isWindows ? 'windsor.exe' : 'windsor';
           const githubEnv = process.env.GITHUB_ENV;
           const input_context = '${{ inputs.context }}';

--- a/action.yaml
+++ b/action.yaml
@@ -168,7 +168,7 @@ runs:
 
                 let installedVersionOutput = execSync(`${path.join(installFolder, windsorExecutable)} version${verbose ? ' --verbose' : ''}`).toString().trim();
                 let installedVersionMatch = installedVersionOutput.match(/^Version:\s*(\S+)/);
-                let installedVersion = installedVersionMatch ? `v${installedVersionMatch[1]}` : '';
+                let installedVersion = installedVersionMatch ? installedVersionMatch[1] : '';
 
                 if (verbose) {
                   console.log('Version check:');
@@ -176,7 +176,8 @@ runs:
                   console.log('- Installed:', installedVersion);
                 }
 
-                if (installedVersion !== ref) {
+                if (!installedVersion || installedVersion !== ref.replace(/^v/, '')) {
+                  if (verbose) console.log('Version mismatch or missing, falling back to building from source');
                   throw new Error(`Version mismatch: expected ${ref}, got ${installedVersion}`);
                 }
               } catch (error) {

--- a/action.yaml
+++ b/action.yaml
@@ -68,59 +68,25 @@ runs:
             console.log('- Install folder:', installFolder);
           }
           
+          // Simple workdir handling
           let workdir;
           if (rawWorkdir) {
-            const workspacePath = process.env.GITHUB_WORKSPACE;
-            // Simple path normalization - no quotes, just slashes
-            const platformPath = rawWorkdir.replace(/\//g, path.sep);
-            
-            if (verbose) {
-              console.log('Workdir resolution:');
-              console.log('- Raw workdir:', rawWorkdir);
-              console.log('- Workspace path:', workspacePath);
-              console.log('- Platform path:', platformPath);
-              console.log('- Platform:', process.platform);
-              console.log('- Path separator:', path.sep);
-            }
-            
-            if (process.platform === 'win32') {
-              // Direct path handling for Windows
-              workdir = path.isAbsolute(platformPath) 
-                ? platformPath 
-                : path.join(workspacePath, platformPath);
-              
-              if (verbose) {
-                console.log('Windows path handling:');
-                console.log('- Final workdir:', workdir);
-              }
+            if (path.isAbsolute(rawWorkdir)) {
+              workdir = rawWorkdir;
             } else {
-              if (path.isAbsolute(platformPath)) {
-                workdir = platformPath;
-              } else {
-                workdir = path.join(workspacePath, platformPath);
-              }
-              if (verbose) {
-                console.log('Unix path handling:');
-                console.log('- Is absolute:', path.isAbsolute(platformPath));
-                console.log('- Final workdir:', workdir);
-              }
-            }
-            if (verbose) {
-              console.log('Final workdir check:');
-              console.log('- Workdir:', workdir);
-              console.log('- Exists:', fs.existsSync(workdir));
-              try {
-                const stats = fs.statSync(workdir);
-                console.log('- Is directory:', stats.isDirectory());
-              } catch (e) {
-                console.log('- Error checking workdir:', e.message);
-              }
+              workdir = path.join(process.env.GITHUB_WORKSPACE, rawWorkdir);
             }
           } else {
             workdir = process.cwd();
-            if (verbose) {
-              console.log('Using current directory:');
-              console.log('- Workdir:', workdir);
+          }
+
+          if (verbose) {
+            console.log('Workdir resolution:');
+            console.log('- Raw workdir:', rawWorkdir);
+            console.log('- Final workdir:', workdir);
+            console.log('- Exists:', fs.existsSync(workdir));
+            if (fs.existsSync(workdir)) {
+              console.log('- Is directory:', fs.statSync(workdir).isDirectory());
             }
           }
 
@@ -129,7 +95,8 @@ runs:
               if (verbose) console.log('Executing:', command);
               execSync(command, { stdio: 'inherit' });
             } catch (error) {
-              process.exit(1);
+              console.error(`Command failed: ${command}`);
+              throw error;
             }
           };
 
@@ -161,9 +128,9 @@ runs:
                 execCommand(chmodCommand);
                 execCommand(rmCommand);
 
-                let installedVersionOutput = execSync(`${path.join(installFolder, windsorExecutable)} version${verbose ? ' --verbose' : ''}`).toString().trim();
-                let installedVersionMatch = installedVersionOutput.match(/^Version:\s*(\S+)/);
-                let installedVersion = installedVersionMatch ? installedVersionMatch[1] : '';
+                const installedVersionOutput = execSync(`${path.join(installFolder, windsorExecutable)} version${verbose ? ' --verbose' : ''}`).toString().trim();
+                const installedVersionMatch = installedVersionOutput.match(/^Version:\s*(\S+)/);
+                const installedVersion = installedVersionMatch ? installedVersionMatch[1] : '';
 
                 if (verbose) {
                   console.log('Version check:');
@@ -172,7 +139,6 @@ runs:
                 }
 
                 if (!installedVersion || installedVersion !== ref.replace(/^v/, '')) {
-                  if (verbose) console.log('Version mismatch or missing, falling back to building from source');
                   throw new Error(`Version mismatch: expected ${ref}, got ${installedVersion}`);
                 }
               } catch (error) {
@@ -184,39 +150,35 @@ runs:
             // If not a version tag or download failed, check for Go and build from source
             if (!isVersionTag || !fs.existsSync(path.join(installFolder, windsorExecutable))) {
               try {
-                const platform = os.platform();
-                let goPathCommand = platform === 'win32' ? 'where go' : 'which go';
-                const goPath = execSync(goPathCommand, { encoding: 'utf-8' }).trim();
-                if (verbose) console.log('Go binary path:', goPath);
-                
+                const goPath = execSync(isWindows ? 'where go' : 'which go', { encoding: 'utf-8' }).trim();
                 const goVersion = execSync('go version', { encoding: 'utf-8' }).trim();
-                if (verbose) console.log('Go version:', goVersion);
+                
+                if (verbose) {
+                  console.log('Go binary path:', goPath);
+                  console.log('Go version:', goVersion);
+                }
 
                 if (verbose) console.log(`Building Windsor CLI from ref: ${ref}`);
                 const tmpDir = path.join(os.tmpdir(), `windsor-build-${Date.now()}`);
                 if (verbose) console.log('Using temporary build directory:', tmpDir);
+                
                 fs.mkdirSync(tmpDir, { recursive: true });
                 execCommand(`git clone https://github.com/windsorcli/cli.git ${tmpDir}`);
                 execCommand(`cd ${tmpDir} && git pull && git checkout ${ref}`);
                 
-                // Ensure we're in the correct directory for Go commands
                 process.chdir(tmpDir);
                 if (!fs.existsSync('go.mod')) {
                   execCommand('go mod init github.com/windsorcli/cli');
                 }
                 execCommand('go mod tidy');
                 
-                // Build in temp directory
                 const tempBuildPath = path.join(tmpDir, 'cmd', 'windsor', windsorExecutable);
                 execCommand(`cd cmd/windsor && go build -o ${tempBuildPath}`);
                 
-                // Create cache directory and copy binary
                 fs.mkdirSync(installFolder, { recursive: true });
                 fs.copyFileSync(tempBuildPath, path.join(installFolder, windsorExecutable));
-                
-                // Temp directory is ephemeral, no need to clean up
               } catch (error) {
-                console.error(error.message);
+                console.error('Build failed:', error.message);
                 process.exit(1);
               }
             }
@@ -229,7 +191,7 @@ runs:
             process.chdir(workdir);
             if (verbose) console.log('Changed to workdir:', workdir);
           } else if (workdir) {
-            console.error(`Workdir does not exist`);
+            console.error(`Workdir does not exist: ${workdir}`);
             process.exit(1);
           }
 

--- a/action.yaml
+++ b/action.yaml
@@ -205,8 +205,16 @@ runs:
                   execCommand('go mod init github.com/windsorcli/cli');
                 }
                 execCommand('go mod tidy');
-                execCommand(`cd cmd/windsor && go build -o ${path.join(installFolder, windsorExecutable)}`);
-                fs.rmSync(tmpDir, { recursive: true, force: true });
+                
+                // Build in temp directory
+                const tempBuildPath = path.join(tmpDir, 'cmd', 'windsor', windsorExecutable);
+                execCommand(`cd cmd/windsor && go build -o ${tempBuildPath}`);
+                
+                // Create cache directory and copy binary
+                fs.mkdirSync(installFolder, { recursive: true });
+                fs.copyFileSync(tempBuildPath, path.join(installFolder, windsorExecutable));
+                
+                // Temp directory is ephemeral, no need to clean up
               } catch (error) {
                 console.error(error.message);
                 process.exit(1);


### PR DESCRIPTION
The `RUNNER_TOOL_CACHE` points to a standard folder for storing tool caches on the actions runner. This PR implements installing the CLI tool to this destination, preventing collisions with preexisting folders. Additionally ensures that if a build is required it does to in a temporary directory.