### PR TITLE
fix: always rebuild CLI for non-semver refs

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -84,7 +84,8 @@ runs:
             }
           };
 
-          if (!fs.existsSync(path.join(installFolder, windsorExecutable))) {
+          // Always rebuild for non-semver refs
+          if (!isVersionTag || !fs.existsSync(path.join(installFolder, windsorExecutable))) {
             const arch = process.arch === 'arm64' ? 'arm64' : 'amd64';
             const osType = isWindows ? 'windows' : process.platform === 'darwin' ? 'darwin' : 'linux';
 


### PR DESCRIPTION
When using non-semver refs (like 'main'), the action was incorrectly using cached versions instead of rebuilding from source. This change ensures that any non-semver ref will trigger a fresh build, while maintaining caching behavior for semver refs.