### PR TITLE
fix: Parse windsor env using KEY=value

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,8 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         ref: 
-          - v0.6.1 # renovate: datasource=github-releases depName=windsorcli/cli
+          # Disable until we get through the v0.7.0 release
+          # - v0.6.1 # renovate: datasource=github-releases depName=windsorcli/cli
           - main
     runs-on: ${{ matrix.os }}
   

--- a/action.yaml
+++ b/action.yaml
@@ -276,75 +276,30 @@ runs:
               throw new Error('windsor env returned no output');
             }
 
-            // Parse environment variables, handling line continuations and wrapped lines
+            // Parse environment variables from windsor env output (KEY=VALUE format)
             const lines = envOutput.split('\n');
             const envVars = new Map();
-            let currentVar = null;
-            let currentValue = '';
             let managedEnvVars = '';
 
             for (let i = 0; i < lines.length; i++) {
               const line = lines[i].trim();
               
-              // Skip empty lines and unset commands
-              if (!line || line.startsWith('unset ')) {
+              // Skip empty lines
+              if (!line) {
                 continue;
               }
 
-              // Handle export statements
-              if (line.startsWith('export ')) {
-                // If we were building a previous variable, finish it
-                if (currentVar) {
-                  envVars.set(currentVar, currentValue.trim());
-                  currentVar = null;
-                  currentValue = '';
-                }
-
-                const assignment = line.replace(/^export /, '');
-                const eqIdx = assignment.indexOf('=');
-                if (eqIdx !== -1) {
-                  const key = assignment.slice(0, eqIdx);
-                  let value = assignment.slice(eqIdx + 1);
-                  
-                  // Check if the line ends with an incomplete quote or seems wrapped
-                  const hasOpenQuote = (value.match(/"/g) || []).length % 2 === 1;
-                  
-                  if (hasOpenQuote || !value.endsWith('"')) {
-                    // This might be a multi-line value, start collecting
-                    currentVar = key;
-                    currentValue = value;
-                  } else {
-                    // Complete assignment on one line
-                    value = value.replace(/^["']|["']$/g, '');
-                    envVars.set(key, value);
-                  }
-                }
-              } else if (line.startsWith('$env:')) {
-                // Windows PowerShell style (not expected in unix, but handle anyway)
-                const match = line.match(/^\$env:([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)$/);
-                if (match) {
-                  const [_, key, rawValue] = match;
-                  let value = rawValue.trim().replace(/^["']|["']$/g, '');
+              // Handle KEY=VALUE format
+              const eqIdx = line.indexOf('=');
+              if (eqIdx !== -1) {
+                const key = line.slice(0, eqIdx);
+                const value = line.slice(eqIdx + 1);
+                
+                // Basic validation for environment variable names
+                if (/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) {
                   envVars.set(key, value);
                 }
-              } else if (currentVar) {
-                // Continuation of a multi-line value
-                currentValue += line;
-                
-                // Check if this completes the value (ends with quote)
-                if (line.endsWith('"')) {
-                  let finalValue = currentValue.replace(/^["']|["']$/g, '');
-                  envVars.set(currentVar, finalValue);
-                  currentVar = null;
-                  currentValue = '';
-                }
               }
-            }
-
-            // Handle any remaining variable
-            if (currentVar) {
-              let finalValue = currentValue.replace(/^["']|["']$/g, '');
-              envVars.set(currentVar, finalValue);
             }
 
             console.log(`Found ${envVars.size} environment variables to inject`);
@@ -352,12 +307,6 @@ runs:
             // Extract managed env vars
             if (envVars.has('WINDSOR_MANAGED_ENV')) {
               managedEnvVars = envVars.get('WINDSOR_MANAGED_ENV');
-            }
-
-            // Add missing TALOSCONFIG if cluster is enabled
-            if (!envVars.has('TALOSCONFIG') && envVars.has('WINDSOR_PROJECT_ROOT')) {
-              const talosConfigPath = path.join(envVars.get('WINDSOR_PROJECT_ROOT'), 'contexts', input_context, '.talos', 'config');
-              envVars.set('TALOSCONFIG', talosConfigPath);
             }
 
             // Process each environment variable


### PR DESCRIPTION
The "windsor env" output no longer includes `export`, etc. and now returns a vanilla list of `KEY=value`. This change broke the action. This update leverages the new format, simplifying the parser.