### PR TITLE
ci: Add latest tagged version to tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,8 +16,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         ref: 
-          # Disable until we get through the v0.7.0 release
-          # - v0.6.1 # renovate: datasource=github-releases depName=windsorcli/cli
+          - v0.7.0 # renovate: datasource=github-releases depName=windsorcli/cli
           - main
     runs-on: ${{ matrix.os }}
   
@@ -121,12 +120,7 @@ jobs:
             const ref = '${{ matrix.ref }}';
             const isMainBranch = ref === 'main';
 
-            // TF_CLI_ARGS_init differs between versions:
-            // - main branch includes -force-copy
-            // - v0.6.1 does not include -force-copy
-            const tfInitArgs = isMainBranch 
-              ? `-backend=true -force-copy -backend-config="path=${projectRoot}/contexts/test/.tfstate/sample/terraform.tfstate"`
-              : `-backend=true -backend-config="path=${projectRoot}/contexts/test/.tfstate/sample/terraform.tfstate"`;
+            const tfInitArgs = `-backend=true -force-copy -backend-config="path=${projectRoot}/contexts/test/.tfstate/sample/terraform.tfstate"`;
 
             let expectedVars;
             if (process.platform === 'win32') {
@@ -232,8 +226,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         ref: 
-          # Disable until we get through the v0.7.0 release
-          # - v0.6.1 # renovate: datasource=github-releases depName=windsorcli/cli
+          - v0.7.0 # renovate: datasource=github-releases depName=windsorcli/cli
           - main
     runs-on: ${{ matrix.os }}
   


### PR DESCRIPTION
Now that we're through the v0.7.0 release, we can move everything forward to use it.