### PR TITLE
ci(test): Fix expectation to include -upgrade flag on init

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         ref: 
-          - v0.7.0 # renovate: datasource=github-releases depName=windsorcli/cli
+          - v0.7.1 # renovate: datasource=github-releases depName=windsorcli/cli
           - main
     runs-on: ${{ matrix.os }}
   
@@ -226,7 +226,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         ref: 
-          - v0.7.0 # renovate: datasource=github-releases depName=windsorcli/cli
+          - v0.7.1 # renovate: datasource=github-releases depName=windsorcli/cli
           - main
     runs-on: ${{ matrix.os }}
   

--- a/action.yaml
+++ b/action.yaml
@@ -6,7 +6,7 @@ inputs:
   ref:
     description: 'Git reference to build Windsor CLI from source or version tag to download'
     required: false
-    default: v0.7.0  # renovate: datasource=github-releases depName=windsorcli/cli
+    default: v0.7.1  # renovate: datasource=github-releases depName=windsorcli/cli
   context:
     description: 'The context to use for Windsor CLI commands'
     required: false


### PR DESCRIPTION
The `-upgrade` flag was added to the default terraform `TF_ARGS_init` var in the cli codebase. Adjusts this expectation in the test.