### PR TITLE
fix: Pin version node20

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -32,6 +32,7 @@ runs:
       id: check-git
       uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
       with:
+        node-version: '20'
         script: |
           const { execSync } = require('child_process');
           try {
@@ -44,6 +45,7 @@ runs:
     - name: Install Windsor CLI
       uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
       with:
+        node-version: '20'
         script: |
           const { execSync } = require('child_process');
           const fs = require('fs');
@@ -175,6 +177,7 @@ runs:
       uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
       if: ${{ inputs.install-only != 'true' }}
       with:
+        node-version: '20'
         script: |
           const { execSync } = require('child_process');
           const fs = require('fs');


### PR DESCRIPTION
The latest github action runner runs node24 by default. The github script action doesn't yet support node24. Pinning to node20 should ensure future compatibility until github script can be updated.